### PR TITLE
PoC Nix-based build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 	rm -rf verilog/
 
 verilog/%.v: src/%.hs
-	stack exec --package clash-ghc -- clash $^ --verilog
+	clash $^ --verilog
 
 circuit/execute/alu.v: verilog/Alu.v
 	@echo "overwriting with compiled clash"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+let
+  # change to nixos/nixpkgs after the following is merged
+  # https://github.com/NixOS/nixpkgs/pull/178868
+  pkgs = import (builtins.fetchTarball {
+    name = "nixpkgs-unstable-arcz-fix-clash";
+    url = "https://github.com/arcz/nixpkgs/archive/cad3ae120f5c9e4fd9c6cc2236f82c64b6f8fda8.tar.gz";
+    sha256 = "sha256:0rmiw11613y929h2qcxklb5zv7dzarwfa6m4qrjbzxz2nq1jk53q";
+  }) {};
+
+  clash = pkgs.haskellPackages.ghcWithPackages (p: with p; [
+    clash-lib clash-ghc clash-prelude
+  ]);
+
+in with pkgs; stdenv.mkDerivation {
+  name = "sholva-dev";
+
+  nativeBuildInputs = [ clash verilog ];
+
+  src = ./.;
+}


### PR DESCRIPTION
It will take some time to build clash but will be cached in nixpkgs later on. Works both on macOS nad Linux. You can test this with:
```
nix-shell
make all
make check
```
`nix-build` doesn't work as I didn't know exactly what should be the output but this is easily fixable.