### PR TITLE
Fix multi-driven `eax` between syscall and register file modules.

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,3 +3,8 @@
 
 # debugging outputs
 *.vcd
+
+# artifacts
+*.ir1
+*.circuit
+*.(private|public)_input

--- a/test/Makefile
+++ b/test/Makefile
@@ -141,6 +141,20 @@ check.e2e.tv: $(E2EGEN) $(TRACE_TEXTS)
 check.tv: check.e2e.tv
 
 #
+# BACK-ENDS
+# 
+BLIF := ../tiny86/tiny86.blif
+
+$(BLIF):
+	$(MAKE) -C ../tiny86 tiny86.blif
+
+%.circuit: %.trace.txt $(BLIF)
+	sv-compositor -b $(BLIF) -w $< -o $@
+
+%.ir1: %.trace.txt $(BLIF)
+	sv-compositor -b $(BLIF) -w $< -o $@
+
+#
 # TOP-LEVEL
 #
 ARCH := $(shell uname -m)

--- a/test/Makefile
+++ b/test/Makefile
@@ -145,6 +145,7 @@ check.tv: check.e2e.tv
 # 
 BLIF := ../tiny86/tiny86.blif
 
+.PHONY: $(BLIF)
 $(BLIF):
 	$(MAKE) -C ../tiny86 tiny86.blif
 

--- a/test/nop.s
+++ b/test/nop.s
@@ -1,0 +1,9 @@
+section .text
+global _start
+
+_start:
+  nop
+
+  ; exit
+  mov     eax, 1
+  int     0x80

--- a/tiny86/.gitignore
+++ b/tiny86/.gitignore
@@ -1,0 +1,9 @@
+*.json
+*.ir1
+*.dot
+*.svg
+
+# Clash artifacts
+circuit/execute/alu.v
+circuit/syscall.v
+*.ir1

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -80,7 +80,7 @@ _lint-haskell: $(CLASH_SRC)
 	hlint $^
 
 .PHONY: _lint-yosys
-_lint-yosys:
+_lint-yosys: tiny86.json
 	yosys -QT -p 'read_json tiny86.json; check'
 
 .PHONY: _lint-synth
@@ -96,4 +96,5 @@ install:
 
 .PHONY: clean
 clean:
-	rm -rf $(CLASH_VERILOG) verilog/
+	rm -rf $(CLASH_VERILOG) verilog/ \
+		tiny86.*

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -30,9 +30,6 @@ tiny86.blif: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 tiny86.json: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 	sv-netlist $(IFLAGS) --json --top tiny86 $^ -o $@
 
-%.circuit: %.blif
-	sv-compositor -b $< -o $@
-
 # FIXME(jl): these `yosys-*` targets should depend on `tiny86.json`,
 # but that re-synthesizes the whole circuit on every invocation?
 

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -19,15 +19,37 @@ ALL_V_WITHOUT_TESTS_OR_CODEGEN := $(CLASH_VERILOG) \
 .PHONY: all
 all: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 
+#
+# Circuit artifacts
+#
 .PHONY: tiny86.blif
 tiny86.blif: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 	sv-netlist $(IFLAGS) --top tiny86 $^ -o $@
 
-%.circuit: %.blif
-	sv-compositor -b $< --output_file $@
+.PHONY: tiny86.json
+tiny86.json: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
+	sv-netlist $(IFLAGS) --json --top tiny86 $^ -o $@
 
-.PHONY: stat
-stat: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
+%.circuit: %.blif
+	sv-compositor -b $< -o $@
+
+# FIXME(jl): these `yosys-*` targets should depend on `tiny86.json`,
+# but that re-synthesizes the whole circuit on every invocation?
+
+# the parametrized verilog module; defaults to top-level
+# e.g., `YOSYS_MODULE=alu make yosys-show` will generate an SVG of the ALU circuit.
+YOSYS_MODULE ?=
+
+.PHONY: yosys-show
+yosys-show:
+	yosys -QT -p 'read_json tiny86.json; show -format svg -prefix ./$(YOSYS_MODULE) $(YOSYS_MODULE)'
+
+.PHONY: yosys-stat
+yosys-stat:
+	yosys -QT -p 'read_json tiny86.json; stat $(YOSYS_MODULE)'
+
+.PHONY: sv-stat
+sv-stat: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 	sv-stat $(IFLAGS) --top tiny86 $^
 
 .PHONY: codegen
@@ -46,7 +68,7 @@ circuit/syscall.v: src/Syscall.hs src/Syscall/*.hs
 	sed '/timescale/d' verilog/Syscall.top/syscall.v > $@
 
 .PHONY: lint
-lint: _lint-verilog _lint-haskell _lint-synth
+lint: _lint-verilog _lint-haskell _lint-synth _lint-yosys
 
 .PHONY: _lint-verilog
 _lint-verilog: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
@@ -57,6 +79,9 @@ _lint-verilog: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 _lint-haskell: $(CLASH_SRC)
 	hlint $^
 
+.PHONY: _lint-yosys
+_lint-yosys:
+	yosys -QT -p 'read_json tiny86.json; check'
 
 .PHONY: _lint-synth
 _lint-synth: codegen $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -22,16 +22,13 @@ all: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 #
 # Circuit artifacts
 #
-.PHONY: tiny86.blif
+
 tiny86.blif: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 	sv-netlist $(IFLAGS) --top tiny86 $^ -o $@
 
-.PHONY: tiny86.json
 tiny86.json: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 	sv-netlist $(IFLAGS) --json --top tiny86 $^ -o $@
 
-# FIXME(jl): these `yosys-*` targets should depend on `tiny86.json`,
-# but that re-synthesizes the whole circuit on every invocation?
 
 # the parametrized verilog module; defaults to top-level
 # e.g., `YOSYS_MODULE=alu make yosys-show` will generate an SVG of the ALU circuit.

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -37,10 +37,6 @@ tiny86.json: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
 # e.g., `YOSYS_MODULE=alu make yosys-show` will generate an SVG of the ALU circuit.
 YOSYS_MODULE ?=
 
-.PHONY: yosys-show
-yosys-show:
-	yosys -QT -p 'read_json tiny86.json; show -format svg -prefix ./$(YOSYS_MODULE) $(YOSYS_MODULE)'
-
 .PHONY: yosys-stat
 yosys-stat:
 	yosys -QT -p 'read_json tiny86.json; stat $(YOSYS_MODULE)'

--- a/tiny86/check.v
+++ b/tiny86/check.v
@@ -52,9 +52,6 @@ fetch fetch1(
   .ebp(n_ebp),
   .eip(n_eip),
   .eflags(n_eflags),
-  .s_eax(ns_eax),
-  .s_ebx(ns_ebx),
-  .s_ecx(ns_ecx),
   .raw_hint1(raw_hint1),
   .raw_hint2(raw_hint2)
 );

--- a/tiny86/circuit/fetch.v
+++ b/tiny86/circuit/fetch.v
@@ -5,7 +5,6 @@ module fetch(
 
   output [95:0] raw_instr,
   output [31:0] eax, ebx, ecx, edx, esi, edi, esp, ebp, eip, eflags,
-  output [31:0] s_eax, s_ebx, s_ecx,
   output [71:0] raw_hint1,
   output [71:0] raw_hint2 
 );


### PR DESCRIPTION
Fix the multi-driven `s_e{a,b,c}x` registers. Previously, these registers were both `assigned` by the syscall and register file modules -- these don't occur at the same time, so there was no visible write conflict. The ternary operator here makes the single-assignment explicit.

Testing:
```sh
nix-shell --pure --run "make test"
```