### PR TITLE
Update Verilog module testbenches with post-syscall trace size

### DIFF
--- a/test/check.tb.yml
+++ b/test/check.tb.yml
@@ -1,8 +1,8 @@
 module: check
 file: ../tiny86/circuit/../check.v
 inputs:
-  - "560 step0"
-  - "560 step1"
+  - "656 step0"
+  - "656 step1"
 outputs:
   - "1 ok"
 

--- a/test/fetch.tb.yml
+++ b/test/fetch.tb.yml
@@ -1,7 +1,7 @@
 module: fetch
 file: ../tiny86/circuit/fetch.v
 inputs:
-  - "560 step"
+  - "656 step"
 outputs:
   - "96 raw_instr"
   - "32 eax"

--- a/test/tiny86.tb.yml
+++ b/test/tiny86.tb.yml
@@ -1,7 +1,7 @@
 module: tiny86
 file: ../tiny86/circuit/tiny86.v
 inputs:
-  - "560 step"
+  - "656 step"
 outputs:
   - "32 o_eax"
   - "32 o_ebx"


### PR DESCRIPTION
From debugging, this fixes a size mismatch between the compiled Verilog testbenches and the generated traces. I believe the effect of this was that the top `656 - 560` bits of the trace for the Verilog module tests (`ls test/*.yml`) were ignored in verification 😬.

Fortunately all these tests still pass, and the contained tests -- beyond the module signatures -- don't explicitly depend on trace length.

- [x] run a `rg "560"` over source and verified there's no remaining instances of the old trace length.
- [ ] generate documentation for a "trace format change" process.