### PR TITLE
Fix test targets to run all Verilog testbenches by default.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -181,7 +181,7 @@ _test-verilog: $(TESTBENCH_EXES)
 
 .PHONY: _test-pipeline
 _test-pipeline: $(PIPELINE_EXES)
-	ruby run-tests $(PIPELINE_MODULES)
+	ruby run-tests
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The `test/Makefile` target `_test-pipeline` previously would only run the full pipeline tests from `check.tb.yml`. Instead, now run all Verilog testbenches by default when running `make test`.