### PR TITLE
Testing dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,8 @@
 version: 2
 updates:
 - package-ecosystem: cargo
-  directory: "/"
+  directory: "/mttn"
   schedule:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: serde
-    versions:
-    - 1.0.125


### PR DESCRIPTION
Add dependabot for `mttn/Cargo.toml`

This allows for paralleled dependency version bumps between sholva and sv-compositor.