### PR TITLE
Use cachix action to avoid re-building nix deps per-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:23.05
+      - uses: cachix/cachix-action@v12
+        with:
+          name: trailofbits
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: mttn
         run: nix build .#mttn
       - name: tiny86


### PR DESCRIPTION
Use cachix to pare down build time on static runtime dependencies.