### PR TITLE
tiny86 derivation caches synthesized circuit

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -148,21 +148,18 @@ check.tv: check.e2e.tv
 #
 # BACK-ENDS
 # 
-BLIF := ../tiny86/tiny86.blif
-
-.PHONY: $(BLIF)
-$(BLIF):
-	$(MAKE) -C ../tiny86 tiny86.blif
+tiny86.blif:
+	tiny86.sh > $@
 
 .PHONY: %.verify
 %.verify: %.circuit
 	wtk-firealarm $^ $(basename $^).public_input $(basename $^).private_input
 
-%.circuit %.public_input %.private_input: %.trace.txt $(BLIF)
-	sv-compositor -b $(BLIF) -w $< -o $@
+%.circuit %.public_input %.private_input: %.trace.txt tiny86.blif
+	sv-compositor -b tiny86.blif -w $< -o $@
 
-%.ir1: %.trace.txt $(BLIF)
-	sv-compositor -b $(BLIF) -w $< -o $@
+%.ir1: %.trace.txt tiny86.blif
+	sv-compositor -b tiny86.blif -w $< -o $@
 
 #
 # TOP-LEVEL
@@ -217,6 +214,3 @@ buffer_overflow_benchmark: buffer_overflow.c
 # produce consumable IR0 artifacts for all generated program traces.
 .PHONY: artifacts
 artifacts: $(TRACE_TEXTS:.trace.txt=.circuit)
-
-%.circuit: %.trace.txt
-	sv-compositor -b ../tiny86/tiny86.blif -o $@ -w $^

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -17,7 +17,7 @@ ALL_V_WITHOUT_TESTS_OR_CODEGEN := $(CLASH_VERILOG) \
 )
 
 .PHONY: all
-all: $(ALL_V_WITHOUT_TESTS_OR_CODEGEN)
+all: tiny86.blif
 
 #
 # Circuit artifacts

--- a/tiny86/derivation.nix
+++ b/tiny86/derivation.nix
@@ -31,5 +31,17 @@ with pkgs; stdenv.mkDerivation {
     nasm
   ];
 
-  dontInstall = true;
+  # a small wrapper to expose the synthesized circuit through a script in the derivation output
+  installPhase = ''
+    mkdir -p $out/circuit
+    mv tiny86.blif $out/circuit
+
+    mkdir -p $out/bin
+    cat << EOF >> $out/bin/tiny86.sh
+    #!/bin/sh
+    cat $out/circuit/tiny86.blif
+    EOF
+
+    chmod +x $out/bin/tiny86.sh
+  '';
 }


### PR DESCRIPTION
Rather than the tiny86 derivation evaluating to no outputs, instead include the synthesis output in the derivation. Includes a trivial shell script to expose the artifact through a program in `$PATH`.