### PR TITLE
Use dependabot-like workflow to open PRs on updated nix dependencies.

### DIFF
--- a/.github/workflows/niv-updates.yml
+++ b/.github/workflows/niv-updates.yml
@@ -1,0 +1,13 @@
+name: Automated niv-managed dependency updates
+on:
+  schedule:
+    - cron:  '0 10 * * *'
+jobs:
+  niv-updater:
+    name: 'Create PRs for niv-managed dependencies'
+    runs-on: ubuntu-latest
+    steps:
+      - name: niv-updater-action
+        uses: knl/niv-updater-action@v12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Include the `niv-updater-action` to include dependabot-styled PRs for updates to sources managed by niv by proxy of the `nix/sources.json` file.