### PR TITLE
Add `meta.platforms`, non-linux-x86 builds fail immediately

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -26,4 +26,10 @@ stdenv.mkDerivation {
     patchShebangs ./test/
   '';
   doCheck = true;
+
+  meta = with lib; {
+    description = "Zero-knowledge proofs for i386 program execution";
+    license = licenses.agpl3Only;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
 }


### PR DESCRIPTION
Currently builds outside of the intended environment get pretty far before failing, this should be more immediately obvious.