### PR TITLE
docs: specify arch requirements explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-shol'va <img src="https://user-images.githubusercontent.com/3059210/147595717-ec80740c-d4eb-4dd5-972a-d57c228c042d.png" width="48">
-=======
+# shol'va <img src="https://user-images.githubusercontent.com/3059210/147595717-ec80740c-d4eb-4dd5-972a-d57c228c042d.png" width="48">
 
 <!-- Icon attribution: Mikla, https://commons.wikimedia.org/wiki/File:Apophis_Symbol_(Stargate).svg -->
 
 [![Build Status](https://github.com/trailofbits/sholva/actions/workflows/ci.yml/badge.svg)](https://github.com/trailofbits/sholva/actions?query=workflow%3ACI)
 
-*shol'va* is a Verilog and [Clash](https://clash-lang.org/) implementation of a Tiny86 trace verifier.
+_shol'va_ is a Verilog and [Clash](https://clash-lang.org/) implementation of a Tiny86 trace verifier.
 
 ## Usage
+
+> **Note**: _shol'va_ does native tracing X86 Linux programs, and as a result is strictly limited to that architecture.
 
 ### Dependencies
 
@@ -16,7 +17,7 @@ Follow the upstream [nix installation instructions](https://nixos.org/download.h
 
 ### Building
 
-*shol'va* currently builds as a sanity test; producing proofs objects for each example in `test`.
+_shol'va_ currently builds as a sanity test; producing proofs objects for each example in `test`.
 To run the build:
 
 ```bash
@@ -76,5 +77,5 @@ Department of Defense or the U.S. Government.
 
 DISTRIBUTION STATEMENT A: Approved for public release, distribution unlimited.
 
-*shol'va* is licensed under the GNU AGPLv3 License. A copy of the terms can
+_shol'va_ is licensed under the GNU AGPLv3 License. A copy of the terms can
 be found in the [LICENSE](./LICENSE) file.

--- a/derivation.nix
+++ b/derivation.nix
@@ -30,6 +30,5 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Zero-knowledge proofs for i386 program execution";
     license = licenses.agpl3Only;
-    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/mttn/derivation.nix
+++ b/mttn/derivation.nix
@@ -23,4 +23,10 @@ rustPlatform.buildRustPackage rec {
   ];
 
   cargoLock = { lockFile = ./Cargo.lock; };
+
+  meta = with lib; {
+    description = "Tiny86 tracer";
+    license = licenses.agpl3Only;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
 }

--- a/tiny86/default.nix
+++ b/tiny86/default.nix
@@ -3,8 +3,9 @@ let
   pkgs = import sources.nixpkgs { };
 
   sv_circuit = import sources.sv_circuit;
-  verilog_tools = import sources.verilog_tools { };
+  verilog_tools = import sources.verilog_tools;
 in pkgs.callPackage ./derivation.nix {
+  sources = sources;
   sv_circuit = sv_circuit;
   verilog_tools = verilog_tools;
 }

--- a/tiny86/derivation.nix
+++ b/tiny86/derivation.nix
@@ -28,4 +28,9 @@ stdenv.mkDerivation {
 
     chmod +x $out/bin/tiny86.sh
   '';
+
+  meta = with lib; {
+    description = "Tiny86 transition circuit";
+    license = licenses.agpl3Only;
+  };
 }


### PR DESCRIPTION
Update and specify the architecture requirements explicitly.

- Only the `mttn` derivation is strictly `x86-linux`.
- Add note at the top of README.

Sneaking in some other fixes here:

- ran `prettier` formatter over the README.
- Fixed inputs to the tiny86 `default.nix` -- now this derivation can be `nix-{build,shell}`'d independently.