### PR TITLE
runtime: add build recipe for threadless i386 gcj

### DIFF
--- a/runtime/gcj/default.nix
+++ b/runtime/gcj/default.nix
@@ -1,0 +1,4 @@
+let
+  sources = import ../../nix/sources.nix;
+  pkgs = import sources.nixpkgs { };
+in pkgs.callPackage ./gcj-i386.nix { sources = sources; }

--- a/runtime/gcj/gcj-i386.nix
+++ b/runtime/gcj/gcj-i386.nix
@@ -1,0 +1,10 @@
+{ sources }:
+let
+  pkgs = (import sources.nixpkgs { }).pkgsi686Linux;
+
+  sholva-gcj = pkgs.gcj.overrideAttrs (oldgjc: rec {
+    cc = oldgjc.cc.overrideAttrs (oldcc: rec {
+      configureFlags = [ "--disable-threads" ] ++ oldcc.configureFlags;
+    });
+  });
+in sholva-gcj


### PR DESCRIPTION
Add `gcj` build recipe to the runtime. Not currently included as a dependency:

- Compiles Java to native ELF
- Threadless

But unfortunately supports only long out-of-date Java versions.