### PR TITLE
mttn: fix construction of rustPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,10 +46,12 @@
         in rec {
           # https://nixos.wiki/wiki/Overlays, "In a Nix flake"
           mttn = with pkgs.extend (import rust-overlay);
-            rustPlatform.buildRustPackage rec {
+            (makeRustPlatform {
+              cargo = rust-bin.beta.latest.default;
+              rustc = rust-bin.beta.latest.default;
+            }).buildRustPackage rec {
               name = "mttn";
               src = ./mttn;
-              buildInputs = [ rust-bin.beta.latest.default ];
               cargoLock = { lockFile = ./mttn/Cargo.lock; };
 
               nativeCheckInputs = [ nasm ];


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text. The below is mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary

The existing use of `rustPlatform` was incorrect.
Two different rust abstraction exist: the `rustPlatform` from nixpkgs, and the `rust-bin` packages provided by the overlay. The platform configures the final Rust toolchain, whereas the binary as a buildInput appears to have been shadowed. Instead, the toolchain should be constructed _with_ the specified toolchain binaries. 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Tested regressioin with `wtk-firealarm`.


#### Release Note

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation

```
nix develop .#mttn --command rustc --version
warning: Git tree '/home/jleightcap/work/sholva' is dirty
rustc 1.73.0-beta.4 (9f37cd4f7 2023-09-01)
```

<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
