### PR TITLE
tiny86: TCL synthesis script

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,22 +74,6 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -240,30 +224,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1689605451,
-        "narHash": "sha256-u2qp2k9V1smCfk6rdUcgMKvBj3G9jVvaPHyeXinjN9E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "53657afe29748b3e462f1f892287b7e254c26d77",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "clash": "clash",
         "flake-compat": "flake-compat_2",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
-        "sv_circuit": "sv_circuit",
-        "verilog_tools": "verilog_tools"
+        "sv_circuit": "sv_circuit"
       }
     },
     "rust-overlay": {
@@ -371,25 +338,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "verilog_tools": {
-      "inputs": {
-        "flake-compat": "flake-compat_4",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1694102475,
-        "narHash": "sha256-CAizNXhm7CHQHl9LKyBafDxb3no/2jrMZrqrAxU+cLU=",
-        "owner": "trailofbits",
-        "repo": "verilog_tools",
-        "rev": "1d301f3743bfa0bf18b5508d3d28bf96f4a04731",
-        "type": "github"
-      },
-      "original": {
-        "owner": "trailofbits",
-        "repo": "verilog_tools",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     sv_circuit = { url = "github:trailofbits/sv_circuit"; };
-    verilog_tools = { url = "github:trailofbits/verilog_tools"; };
   };
 
-  outputs = { self, clash, nixpkgs, flake-compat, rust-overlay, sv_circuit
-    , verilog_tools, ... }:
+  outputs =
+    { self, clash, nixpkgs, flake-compat, rust-overlay, sv_circuit, ... }:
     let
       supportedSystems = [ "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -74,10 +73,8 @@
             buildInputs = [
               clash.packages.${system}.clash-ghc
               clash.packages.${system}.clash-prelude
-            ] ++ [
               sv_circuit.packages.${system}.sv_circuit
-              verilog_tools.packages.${system}.verilog_tools
-            ] ++ (with pkgs; [ nasm python3 verible verilator verilog ]);
+            ] ++ (with pkgs; [ nasm python3 verible verilator verilog yosys ]);
 
             checkInputs = with pkgs; [ mttn ruby ];
             preCheck = ''

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -126,8 +126,16 @@ test/%.tb.vvp: test/%.tb.gen.v
 #
 # Circuit artifacts
 #
+
+## ZK gate mappings
+synth.tcl: zk.lib
+
+## TCL builder script
+$(CIRCUIT_SRC): synth.tcl
+
+## circuit synthesis
 tiny86.blif: $(CIRCUIT_SRC)
-	sv-netlist $(IFLAGS) --top check $^ -o $@
+	yosys -c synth.tcl $^
 
 #
 # Formatting

--- a/tiny86/circuit/decode/decode_hint.v
+++ b/tiny86/circuit/decode/decode_hint.v
@@ -11,7 +11,7 @@ module decode_hint (
     output [31:0] data
 );
 
-  `include "funcs.v"
+  `include "../include/funcs.v"
 
   wire [7:0] meta = raw_hint[71:64];
 

--- a/tiny86/circuit/decode/decode_opc_phase2.v
+++ b/tiny86/circuit/decode/decode_opc_phase2.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
-`include "defines.v"
-`include "codegen/commands.gen.v"
+`include "../include/defines.v"
+`include "../codegen/commands.gen.v"
 
 module decode_opc_phase2 (
     input [87:0] unescaped_instr,
@@ -33,6 +33,6 @@ module decode_opc_phase2 (
   wire [7:0] opc_without_regs = unescaped_instr[7:0] & 8'b11111000;
 
   // Off to the races.
-  `include "codegen/opc_map.gen.v"
+  `include "../codegen/opc_map.gen.v"
 
 endmodule

--- a/tiny86/circuit/decode/decode_opnd_signals.v
+++ b/tiny86/circuit/decode/decode_opnd_signals.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
-`include "codegen/commands.gen.v"
-`include "defines.v"
+`include "../codegen/commands.gen.v"
+`include "../include/defines.v"
 
 module decode_opnd_signals (
     input [87:0] unescaped_instr,
@@ -34,7 +34,7 @@ module decode_opnd_signals (
     output opnd1_disp
 );
 
-  `include "funcs.v"
+  `include "../include/funcs.v"
 
   wire [15:0] opnd_form_1hot = one_hot16(opnd_form);
 
@@ -179,7 +179,7 @@ module decode_opnd_signals (
   wire is_imm16 = has_imm && prefix_operand_16bit;
   wire is_imm32 = has_imm && (~is_imm8 && ~is_imm16);
 
-  `include "codegen/imm.gen.v"
+  `include "../codegen/imm.gen.v"
 
   wire [2:0] imm_len = is_imm32 ? 3'd4 : is_imm16 ? 3'd2 : is_imm8 ? 3'd1 : 3'd0;
 

--- a/tiny86/circuit/decode/decode_opnds.v
+++ b/tiny86/circuit/decode/decode_opnds.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
-`include "codegen/commands.gen.v"
-`include "defines.v"
+`include "../codegen/commands.gen.v"
+`include "../include/defines.v"
 
 module decode_opnds(
   input [87:0] unescaped_instr,
@@ -45,7 +45,7 @@ module decode_opnds(
   output [31:0] dest1_sel
 );
 
-`include "funcs.v"
+`include "../include/funcs.v"
 
 wire [3:0] imm_disp_len;
 wire has_imm;

--- a/tiny86/circuit/execute/cfu.v
+++ b/tiny86/circuit/execute/cfu.v
@@ -5,8 +5,8 @@
 // 4. Control flow transfer, absolute displacement
 `default_nettype none
 
-`include "defines.v"
-`include "codegen/commands.gen.v"
+`include "../include/defines.v"
+`include "../codegen/commands.gen.v"
 
 module cfu (
     input [6:0] opc,
@@ -19,7 +19,7 @@ module cfu (
     output [31:0] next_eip
 );
 
-  `include "funcs.v"
+  `include "../include/funcs.v"
 
   wire [127:0] opc_1hot = one_hot128(opc);
 

--- a/tiny86/circuit/execute/execute.v
+++ b/tiny86/circuit/execute/execute.v
@@ -1,6 +1,7 @@
 `default_nettype none
-`include "defines.v"
-`include "codegen/commands.gen.v"
+
+`include "../include/defines.v"
+`include "../codegen/commands.gen.v"
 
 module execute (
     input [6:0] opc,
@@ -21,7 +22,7 @@ module execute (
     output [31:0] opnd1_w
 );
 
-  `include "funcs.v"
+  `include "../include/funcs.v"
 
   wire [127:0] opc_1hot = one_hot128(opc);
 

--- a/tiny86/circuit/execute/meta.v
+++ b/tiny86/circuit/execute/meta.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
-`include "defines.v"
-`include "codegen/commands.gen.v"
+`include "../include/defines.v"
+`include "../codegen/commands.gen.v"
 
 module meta (
     input [ 6:0] opc,
@@ -13,7 +13,7 @@ module meta (
     output [6:0] status_out
 );
 
-  `include "funcs.v"
+  `include "../include/funcs.v"
 
   wire [127:0] opc_1hot = one_hot128(opc);
 

--- a/tiny86/circuit/execute/move.v
+++ b/tiny86/circuit/execute/move.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
-`include "defines.v"
-`include "codegen/commands.gen.v"
+`include "../include/defines.v"
+`include "../codegen/commands.gen.v"
 
 module move (
     // Inputs.

--- a/tiny86/circuit/regfile.v
+++ b/tiny86/circuit/regfile.v
@@ -1,5 +1,6 @@
 `default_nettype none
-`include "defines.v"
+
+`include "./include/defines.v"
 
 module regfile (
     // register file enabled.
@@ -46,7 +47,7 @@ module regfile (
     o_eflags
 );
 
-  `include "funcs.v"
+  `include "./include/funcs.v"
 
   wire [7:0] dest0_sel_1hot = one_hot8(dest0_sel);
   wire [7:0] dest1_sel_1hot = one_hot8(dest1_sel);

--- a/tiny86/circuit/tiny86.v
+++ b/tiny86/circuit/tiny86.v
@@ -1,5 +1,6 @@
 `default_nettype none
-`include "defines.v"
+
+`include "./include/defines.v"
 
 module tiny86 (
     input [655:0] step,

--- a/tiny86/synth.tcl
+++ b/tiny86/synth.tcl
@@ -1,0 +1,14 @@
+yosys -import
+
+hierarchy -check -top check
+procs
+memory
+fsm
+techmap
+opt -purge
+abc -liberty zk.lib
+rmports
+opt
+clean 
+read_liberty -lib zk.lib
+write_blif -gates -impltf -buf BUF IN OUT tiny86.blif

--- a/tiny86/zk.lib
+++ b/tiny86/zk.lib
@@ -1,0 +1,25 @@
+library(boolean) {
+    cell(NOT) {
+        area: 2;
+        pin(IN) { direction: input; }
+        pin(OUT) { direction: output; function: "IN'"; }
+    }
+    cell(XOR) {
+        area: 1;
+        pin(A) { direction: input; }
+        pin(B) { direction: input; }
+        pin(OUT) { direction: output; function: "(A^B)"; }
+    }
+    cell(AND) {
+        area: 100;
+        preferred: false;
+        pin(A) { direction: input; }
+        pin(B) { direction: input; }
+        pin(OUT) { direction: output; function: "(A&B)"; }
+    }
+    cell(BUF) {
+        area: 1;
+        pin(IN) { direction: input; }
+        pin(OUT) { direction: output; function: "IN"; }
+    }
+}


### PR DESCRIPTION
use a yosys synthesis script (`synth.tcl`) in place of the yosys
interface (`sv-netlist`) from verilog_tools.
this provides:

- easier to access synthesis parameters (just edit the TCL locally and re-build)
- exposes the build phases in `synth.tcl` and the ZK gate library in `zk.lib`.
- prints build logging from within yosys, per-phase

closes https://github.com/trailofbits/sholva/issues/143, and therefore removes all dependencies on verilog_tools.
(one step closer to monorepo).

when running `sv-netlist`, a log is printed per command sent to yosys.
so, copying this log, and pulling out the argument in each line verbatim, you get the core of `synth.tcl`.

this PR comes with one tradeoff compared to the existing implementation.
the root issue is `yosys` scripts break `\`includes` with paths set by `-I`[^1].

[^1]: i asked about this on IRC, confirmed issue because the CLI code is "a mess"

so, to work around the issue, this PR sets absolute paths to the include files.
something like

```verilog
`include "include.v"
```

set to be importable with `-I../include`,
needs to point directly to that path:

```verilog
`include "../include/include.v"
```

i think this is a pretty fair tradeoffs.
we don't really restructure this code.

confirming each test still validates:

on branch `main`:

```sh
$ cd tiny86
$ nix develop .#tiny86
[nix-shell]$ make tiny86.blif
(cut)
[nix-shell]$ mv tiny86.blif tiny86-sv-netlist.blif
```

checkout branch `jl/yosys-script`:

```sh
[nix-shell]$ git checkout jl/yosys-script
[nix-shell]$ make -C test &> log_sv-netlist.log
[nix-shell]$ make tiny86.blif
(cut)
[nix-shell]$ mv tiny86.blif tiny86-script.blif
```

diff circuits and compare `wtk-firealarm` output.

- circuit's are _not_ bit-for-bit identical.
  however, the diff seems to be only wire numbering changes.
- ZK tests are same (regressions in https://github.com/trailofbits/sholva/issues/211 present.)

Signed-off-by: Jack Leightcap <jack.leightcap@trailofbits.com>