### PR TITLE
tiny86 testing fixups

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,10 +77,9 @@
             ] ++ [
               sv_circuit.packages.${system}.sv_circuit
               verilog_tools.packages.${system}.verilog_tools
-            ] ++ (with pkgs; [ nasm python3 verible verilator ]);
-            propagatedBuildInputs = with pkgs; [ ruby verilog ];
+            ] ++ (with pkgs; [ nasm python3 verible verilator verilog ]);
 
-            checkInputs = [ mttn ];
+            checkInputs = with pkgs; [ mttn ruby ];
             preCheck = ''
               patchShebangs test/
               cp -f ${mttn}/traces/*.trace.txt test/

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -94,7 +94,7 @@ _test-clash: $(CLASH_SRC) $(CLASH_TESTS)
 
 .PHONY: _test-verilog
 _test-verilog: $(TESTBENCHES)
-	./test/run-tests $^ || true # FIXME
+	./test/run-tests $^ 
 
 check.tb.yml: check.e2e.tv
 
@@ -163,7 +163,7 @@ _lint-yosys: tiny86.blif
 	yosys -QT -p 'read_blif $^; check'
 
 .PHONY: _lint-synth
-_lint-synth: $(CIRCUIT_CODGEN) $(VERILOG_SRC)
+_lint-synth: $(CIRCUIT_CODEGEN) $(VERILOG_SRC)
 	iverilog $(IVERILOG_FLAGS) $(IFLAGS) \
 		-ycircuit \
 		-ycircuit/decode \

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -36,8 +36,8 @@ VERILOG_SRC = \
 )
 
 # All verilog.
-CIRCUIT_SRC := $(VERILOG_CLASH) $(VERILOG_SRC)
-$(CIRCUIT_SRC): circuit-codegen
+CIRCUIT_CODEGEN := cirucit/codegen/commands.gen.v cirucit/codegen/opc_map.gen.v
+CIRCUIT_SRC := $(VERILOG_CLASH) $(VERILOG_SRC) $(CIRCUIT_CODEGEN)
 
 SHOLVA_MODULES ?= \
 	agu \
@@ -62,16 +62,15 @@ SHOLVA_MODULES ?= \
 #
 # Synthesis
 #
-.PHONY: circuit-codegen
-circuit-codegen:
+$(CIRCUIT_CODEGEN):
 	$(MAKE) -C circuit/codegen
 
 circuit/execute/alu.v: src/Alu.hs src/Alu/*.hs
-	clash -isrc -fclash-clear $< --verilog
+	clash -isrc $< --verilog
 	sed '/timescale/d' verilog/Alu.top/alu.v > $@
 
 circuit/syscall.v: src/Syscall.hs src/Syscall/*.hs
-	clash -isrc -fclash-clear $< --verilog
+	clash -isrc $< --verilog
 	sed '/timescale/d' verilog/Syscall.top/syscall.v > $@
 
 #
@@ -163,7 +162,7 @@ _lint-yosys: tiny86.blif
 	yosys -QT -p 'read_blif $^; check'
 
 .PHONY: _lint-synth
-_lint-synth: circuit-codegen $(VERILOG_SRC)
+_lint-synth: $(CIRCUIT_CODGEN) $(VERILOG_SRC)
 	iverilog $(IVERILOG_FLAGS) $(IFLAGS) \
 		-ycircuit \
 		-ycircuit/decode \

--- a/tiny86/Makefile
+++ b/tiny86/Makefile
@@ -36,8 +36,11 @@ VERILOG_SRC = \
 )
 
 # All verilog.
-CIRCUIT_CODEGEN := cirucit/codegen/commands.gen.v cirucit/codegen/opc_map.gen.v
-CIRCUIT_SRC := $(VERILOG_CLASH) $(VERILOG_SRC) $(CIRCUIT_CODEGEN)
+CIRCUIT_CODEGEN = circuit/codegen/commands.gen.v cicuit/codegen/opc_map.gen.v
+$(CIRCUIT_CODEGEN):
+	$(MAKE) -C circuit/codegen
+CIRCUIT_SRC = $(VERILOG_CLASH) $(VERILOG_SRC)
+$(CIRCUIT_SRC): $(CIRCUIT_CODEGEN)
 
 SHOLVA_MODULES ?= \
 	agu \
@@ -62,8 +65,6 @@ SHOLVA_MODULES ?= \
 #
 # Synthesis
 #
-$(CIRCUIT_CODEGEN):
-	$(MAKE) -C circuit/codegen
 
 circuit/execute/alu.v: src/Alu.hs src/Alu/*.hs
 	clash -isrc $< --verilog

--- a/tiny86/src/Syscall.hs
+++ b/tiny86/src/Syscall.hs
@@ -16,6 +16,7 @@ todo = undefined
 syscall' :: SyscallDFAState -> Syscall -> SyscallDFAState
 syscall' dfaState =
     \case
+        SYSCALL_NONE -> MkDFAState {eax = 0, ebx = 0, ecx = 0, state = SYSCALL_STATE_DONE}
         SYSCALL_TERMINATE -> todo
         SYSCALL_TRANSMIT -> syscallTransmitDFA dfaState
         SYSCALL_RECEIVE -> syscallReceiveDFA dfaState

--- a/tiny86/src/Syscall/Internal.hs
+++ b/tiny86/src/Syscall/Internal.hs
@@ -23,7 +23,8 @@ stepPtrBytes = 2 * 4 -- the number of address bytes present per step.
 
 -- see: https://cgc-docs.legitbs.net/libcgc/cgcabi/
 data Syscall
-    = SYSCALL_TERMINATE
+    = SYSCALL_NONE
+    | SYSCALL_TERMINATE
     | SYSCALL_TRANSMIT
     | SYSCALL_RECEIVE
     | SYSCALL_FDWAIT
@@ -37,6 +38,7 @@ type SyscallReg = BitVector 32
 -- auto-derived Enum on Syscall (reasonably) enumerates from 0;
 -- so, implement Enum instance manually.
 instance Enum Syscall where
+    fromEnum SYSCALL_NONE = 0
     fromEnum SYSCALL_TERMINATE = 1
     fromEnum SYSCALL_TRANSMIT = 2
     fromEnum SYSCALL_RECEIVE = 3
@@ -44,6 +46,7 @@ instance Enum Syscall where
     fromEnum SYSCALL_ALLOCATE = 5
     fromEnum SYSCALL_DEALLOCATE = 6
     fromEnum SYSCALL_RANDOM = 7
+    toEnum 0 = SYSCALL_NONE
     toEnum 1 = SYSCALL_TERMINATE
     toEnum 2 = SYSCALL_TRANSMIT
     toEnum 3 = SYSCALL_RECEIVE

--- a/tiny86/test/cfu.tb.yml
+++ b/tiny86/test/cfu.tb.yml
@@ -46,7 +46,7 @@ vector_specs:
   - _description: "CMD_JLE (conditional, rel xfer (disp8), not taken)"
 
     # INPUTS
-    opc: 80 # CMD_JLE
+    opc: 81 # CMD_JLE
     eflags: 0x02 # not taken: ZF=0 and SF=OF=0
     eip: 0x08049026
     instr_len: 2
@@ -58,7 +58,7 @@ vector_specs:
   - _description: "CMD_JLE (conditional, rel xfer (disp8), taken)"
 
     # INPUTS
-    opc: 80 # CMD_JLE
+    opc: 81 # CMD_JLE
     eflags: 0b0000000001000010 # taken: ZF=1
     eip: 0x08049026
     instr_len: 2

--- a/tiny86/test/decode.tb.yml
+++ b/tiny86/test/decode.tb.yml
@@ -129,7 +129,7 @@ vector_specs:
 
     # OUTPUTS
     instr_len: 2
-    opc: 80 # CMD_JLE
+    opc: 81 # CMD_JLE
     opnd0_r: 0x11 # pre-adjust
 
   - _description: "cmp DWORD PTR [ebp-0x4],0xa (ebp=0xffc51afc)"
@@ -236,7 +236,7 @@ vector_specs:
 
     # OUTPUTS
     instr_len: 2
-    opc: 82 # CMD_LOOPE
+    opc: 83 # CMD_LOOPE
     opnd0_r: 0x00
     opnd1_r: 50
     opnd2_r: 1
@@ -251,7 +251,7 @@ vector_specs:
 
     # OUTPUTS
     instr_len: 2
-    opc: 83 # CMD_LOOPNE
+    opc: 84 # CMD_LOOPNE
     opnd0_r: 0x00
     opnd1_r: 1
     opnd2_r: 1

--- a/tiny86/test/decode_opnds.tb.yml
+++ b/tiny86/test/decode_opnds.tb.yml
@@ -611,7 +611,7 @@ vector_specs:
     hint1_is_write: 0
     hint1_address: 0xffffd9a8
     hint1_data: 0xffffd9bc
-    opc: 84 # CMD_LEAVE
+    opc: 85 # CMD_LEAVE
     opnd_form: 0 # OPND_ENC_NONE
 
     # OUTPUTS

--- a/tiny86/test/execute.tb.yml
+++ b/tiny86/test/execute.tb.yml
@@ -133,7 +133,7 @@ vector_specs:
   - _description: "CMD_LEAVE"
 
     # INPUTS
-    opc: 84 # CMD_LEAVE
+    opc: 85 # CMD_LEAVE
     eip: 0x08049048
     instr_len: 1
     opnd0_r: 0xffffd9bc # [ESP]
@@ -148,7 +148,7 @@ vector_specs:
   - _description: "CMD_SUB (2 - 3)"
 
     # INPUTS
-    opc: 53
+    opc: 53 # CMD_SUB
     eflags: 0x82
     eip: 0x08049013
     instr_len: 3

--- a/tiny86/test/regfile.tb.yml
+++ b/tiny86/test/regfile.tb.yml
@@ -1,6 +1,7 @@
 module: regfile
 file: ../circuit/regfile.v
 inputs:
+  - "1 en"
   - "32 i_eax"
   - "32 i_ebx"
   - "32 i_ecx"
@@ -9,6 +10,8 @@ inputs:
   - "32 i_edi"
   - "32 i_esp"
   - "32 i_ebp"
+  - "32 i_eip"
+  - "32 i_eflags"
   - "2 dest0_kind"
   - "2 dest1_kind"
   - "3 dest0_sel"
@@ -32,6 +35,7 @@ vector_specs:
   - _description: "update one GPR (EBX)"
 
     # INPUTS
+    en: 0b1
     i_ebx: 0xAAAAAAAA
     dest0_kind: 0b01 # OPND_DEST_REG
     dest0_sel: 3 # EBX
@@ -43,6 +47,7 @@ vector_specs:
   - _description: "update two GPRs (ECX:EDX)"
 
     # INPUTS
+    en: 0b1
     i_ecx: 0x11111111
     i_edx: 0x22222222
     dest0_kind: 0b01
@@ -59,6 +64,7 @@ vector_specs:
   - _description: "update no GPRs (kind is not reg)"
 
     # INPUTS
+    en: 0b1
     i_eax: 0xAAAAAAAA
     dest0_kind: 0b10 # OPND_DEST_MEM
     dest0_sel: 0 # EAX
@@ -70,6 +76,7 @@ vector_specs:
   - _description: "update EIP"
 
     # INPUTS
+    en: 0b1
     next_eip: 0x41414141
 
     # OUTPUTS
@@ -78,6 +85,7 @@ vector_specs:
   - _description: "update EFLAGS"
 
     # INPUTS
+    en: 0b1
     next_eflags: 0x12121212
 
     # OUTPUTS
@@ -86,6 +94,7 @@ vector_specs:
   - _description: "update ECX"
 
     # INPUTS
+    en: 0b1
     dest0_kind: 0b01
     dest0_sel: 1
     opnd0_w: 0x11111111

--- a/tiny86/test/run-tests
+++ b/tiny86/test/run-tests
@@ -1,4 +1,4 @@
-#!/nix/store/wcy993wz0zlcixaxivi6gha33afwq66n-ruby-3.1.4/bin/ruby
+#!/usr/bin/env ruby
 # run-tests: collect all .vvps and run each, parsing the output of each run
 # produce output in TAP format
 
@@ -16,7 +16,7 @@ verbose "discovered #{vvps.size} testbenches: #{vvps}"
 puts "1..#{vvps.size}"
 
 vvps.each_with_index do |vvp, i|
-  lines = `vvp #{vvp} -lxt2`.split "\n"
+  lines = `vvp #{vvp} -N -lxt2`.split "\n"
 
   abort "uh oh" if lines.any? { |l| l.start_with? "ERROR:" }
 


### PR DESCRIPTION
- tiny86: test: fix module signature regressions.
- tiny86: test: ruby as check-only dependency
- tiny86: correct Clash dependency tracking
- tiny86: syscall module explicit zero defaults
- tiny86: run-tests fixup

Fixes `run-tests` component of #211.