### PR TITLE
sv_circuit: memory proof

### DIFF
--- a/sv_circuit/gadgets/.gitignore
+++ b/sv_circuit/gadgets/.gitignore
@@ -1,0 +1,2 @@
+verilog/
+*.blif

--- a/sv_circuit/gadgets/Makefile
+++ b/sv_circuit/gadgets/Makefile
@@ -1,8 +1,8 @@
 all: intra_bucket.blif
 
-intra_bucket.blif: src/IntraBucket.hs
+intra_bucket.blif: src/IntraBucket.hs src/MemoryHint.hs src/MemoryBucket.hs
 	clash -isrc $< --verilog
-	yosys verilog/IntraBucket.top/intra_bucket.v -o $@
+	yosys -c synth.tcl verilog/IntraBucket.top/intra_bucket.v
 
 .PHONY: clean
 clean:

--- a/sv_circuit/gadgets/Makefile
+++ b/sv_circuit/gadgets/Makefile
@@ -1,0 +1,9 @@
+all: intra_bucket.blif
+
+intra_bucket.blif: src/IntraBucket.hs
+	clash -isrc $< --verilog
+	yosys verilog/IntraBucket.top/intra_bucket.v -o $@
+
+.PHONY: clean
+clean:
+	rm -f *.blif

--- a/sv_circuit/gadgets/src/IntraBucket.hs
+++ b/sv_circuit/gadgets/src/IntraBucket.hs
@@ -3,7 +3,47 @@ module IntraBucket where
 import Clash.Annotations.TH
 import Clash.Prelude
 
-top :: ("a" ::: Signal System Bit) -> ("b" ::: Signal System Bit)
-top = id
+import MemoryBucket
+import MemoryHint
+
+-- if the public hint's address does not match the bucket's label, return TRUE.
+-- if the public hint's address falls outside of the .text section, return FALSE.
+-- otherwise, validate:
+intraBucket :: MemoryBucket -> MemoryHint -> Bool
+intraBucket bucket hint =
+    if (MemoryBucket.address bucket /= MemoryHint.address hint)
+        then True
+        else memoryInitialization bucket && association bucket
+
+-- verify that the first entry in bucket is a write, either at T=0,
+-- or as an instruction side effect (i.e. if the byte is written before it is read during an execution.)
+memoryInitialization :: MemoryBucket -> Bool
+memoryInitialization bucket =
+    MemoryHint.timestamp (MemoryBucket.hints bucket !! 0) == 0
+
+-- verify that every read has an associated write: a value read must be the most recently
+-- written, and a read and write cannot happen at the same time.
+association :: MemoryBucket -> Bool
+association bucket =
+    foldr
+        (\hint acc -> hasAssoc bucket hint && acc)
+        True
+        (MemoryBucket.hints bucket)
+  where
+    hasAssoc :: MemoryBucket -> MemoryHint -> Bool
+    hasAssoc bucket write =
+        foldr
+            (\hint acc ->
+                 ((MemoryHint.val hint) == (MemoryHint.val write) &&
+                  (MemoryHint.operation hint) == OpWrite) &&
+                 (MemoryHint.timestamp write) < (MemoryHint.timestamp hint) ||
+                 acc)
+            False
+            (MemoryBucket.hints bucket)
+
+top :: ( "bucket" ::: Signal System MemoryBucket
+       , "hint" ::: Signal System MemoryHint)
+    -> ("valid" ::: Signal System Bool)
+top (bucket, hint) = intraBucket <$> bucket <*> hint
 
 makeTopEntityWithName 'top "intra_bucket"

--- a/sv_circuit/gadgets/src/IntraBucket.hs
+++ b/sv_circuit/gadgets/src/IntraBucket.hs
@@ -1,0 +1,9 @@
+module IntraBucket where
+
+import Clash.Annotations.TH
+import Clash.Prelude
+
+top :: ("a" ::: Signal System Bit) -> ("b" ::: Signal System Bit)
+top = id
+
+makeTopEntityWithName 'top "intra_bucket"

--- a/sv_circuit/gadgets/src/MemoryBucket.hs
+++ b/sv_circuit/gadgets/src/MemoryBucket.hs
@@ -1,0 +1,11 @@
+module MemoryBucket
+    ( MemoryBucket(..)
+    ) where
+
+import Clash.Prelude
+import MemoryHint
+
+data MemoryBucket = MkMemoryBucket
+    { address :: BitVector 64
+    , hints :: Vec 10 MemoryHint -- NOTE: precondition of being sorted by timestamp.
+    } deriving (Eq)

--- a/sv_circuit/gadgets/src/MemoryHint.hs
+++ b/sv_circuit/gadgets/src/MemoryHint.hs
@@ -1,0 +1,31 @@
+-- represents an atomic memory operation for memory proof constructions.
+-- diverges slightly from contents of a MemoryHint defined in mttn.
+module MemoryHint
+    ( MemoryOp(..)
+    , MemoryMask(..)
+    , MemoryHint(..)
+    ) where
+
+import Clash.Prelude
+
+type TimeStamp = BitVector 16
+
+data MemoryOp
+    = OpRead
+    | OpWrite
+    deriving (Eq)
+
+data MemoryMask
+    = Byte
+    | Word
+    | DWord
+    | QWord
+    deriving (Eq)
+
+data MemoryHint = MkMemoryHint
+    { address :: BitVector 64
+    , operation :: MemoryOp
+    , mask :: MemoryMask
+    , val :: Vec 8 (BitVector 8) -- 8-byte buffer with mask field
+    , timestamp :: TimeStamp
+    } deriving (Eq)

--- a/sv_circuit/gadgets/synth.tcl
+++ b/sv_circuit/gadgets/synth.tcl
@@ -1,0 +1,15 @@
+yosys -import
+
+hierarchy -check -top intra_bucket
+procs
+memory
+fsm
+techmap
+opt -purge
+abc -liberty zk.lib -fast
+rmports
+opt
+flatten
+clean 
+read_liberty -lib zk.lib
+write_blif -gates -impltf -buf BUF IN OUT intra_bucket.blif

--- a/sv_circuit/gadgets/zk.lib
+++ b/sv_circuit/gadgets/zk.lib
@@ -1,0 +1,25 @@
+library(boolean) {
+    cell(NOT) {
+        area: 2;
+        pin(IN) { direction: input; }
+        pin(OUT) { direction: output; function: "IN'"; }
+    }
+    cell(XOR) {
+        area: 1;
+        pin(A) { direction: input; }
+        pin(B) { direction: input; }
+        pin(OUT) { direction: output; function: "(A^B)"; }
+    }
+    cell(AND) {
+        area: 100;
+        preferred: false;
+        pin(A) { direction: input; }
+        pin(B) { direction: input; }
+        pin(OUT) { direction: output; function: "(A&B)"; }
+    }
+    cell(BUF) {
+        area: 1;
+        pin(IN) { direction: input; }
+        pin(OUT) { direction: output; function: "IN"; }
+    }
+}

--- a/sv_circuit/src/export.rs
+++ b/sv_circuit/src/export.rs
@@ -53,7 +53,7 @@ pub fn private<F: Write>(writer: &mut F, witness: &Witness) -> Result<()> {
 }
 
 /// emit total IR0 circuit.
-pub fn circuit<F: Write>(
+fn execution<F: Write>(
     circuit_writer: &mut F,
     tiny86: &BoolCircuit,
     witness: &Witness,
@@ -221,4 +221,12 @@ pub fn circuit<F: Write>(
     }
     writeln!(circuit_writer, "@end")?;
     Ok(())
+}
+
+pub fn circuit<F: Write>(
+    circuit_writer: &mut F,
+    tiny86: &BoolCircuit,
+    witness: &Witness,
+) -> Result<()> {
+    execution(circuit_writer, tiny86, witness)
 }

--- a/sv_circuit/src/export.rs
+++ b/sv_circuit/src/export.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::ops::Range;
 
-pub fn intra_bucket() -> Result<()> {
+pub fn intra_bucket() -> Result<BoolCircuit> {
     use crate::parse;
     use mcircuit::parsers::blif::BlifParser;
     use mcircuit::Parse;

--- a/sv_circuit/src/export.rs
+++ b/sv_circuit/src/export.rs
@@ -9,6 +9,19 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::ops::Range;
 
+pub fn intra_bucket() -> Result<()> {
+    use crate::parse;
+    use mcircuit::parsers::blif::BlifParser;
+    use mcircuit::Parse;
+    use std::fs::File;
+    use std::io::BufReader;
+
+    File::open("gadgets/intra_bucket.blif")
+        .map(BufReader::new)
+        .map(BlifParser::<bool>::new)
+        .map(parse::blif)?
+}
+
 pub fn public<F: Write>(writer: &mut F) -> Result<()> {
     writeln!(writer, "version 2.0.0-beta;")?;
     writeln!(writer, "public_input;")?;


### PR DESCRIPTION
`intra_bucket.blif` as of 446c3d1e244579061e38a7c129f4ce653e902054
```
yosys> stat

12. Printing statistics.

=== intra_bucket ===

   Number of wires:              19740
   Number of wire bits:         243658
   Number of public wires:        5292
   Number of public wire bits:   75664
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:            101
   Number of cells:              17440
     $_AND_                       5546
     $_MUX_                          1
     $_NOT_                        721
     $_OR_                        5128
     $_XOR_                       6044
```